### PR TITLE
[CI] check ctrl with type=cf instead of number=0

### DIFF
--- a/fdb_utils/ci/check_archive_status.py
+++ b/fdb_utils/ci/check_archive_status.py
@@ -35,7 +35,7 @@ class Parameter:
 COLLECTIONS: dict[str, Collection] = {
     "icon-ch1-eps": Collection(
         model="icon-ch1-eps",
-        members=11,
+        members=11, # ctrl + 10 members
         steps=33,
         forecasts=8,
         interval=dt.timedelta(hours=3),
@@ -43,7 +43,7 @@ COLLECTIONS: dict[str, Collection] = {
     ),
     "icon-ch2-eps": Collection(
         model="icon-ch2-eps",
-        members=21,
+        members=21, # ctrl + 20 members
         steps=121,
         forecasts=4,
         interval=dt.timedelta(hours=6),
@@ -54,10 +54,10 @@ COLLECTIONS: dict[str, Collection] = {
 
 # The poller archives the hourly rotlatlon grib files for constant params (suffix 'c'), single and multi level params
 # (no suffix), and params on pressure levels (suffix 'p'). Each file contains data for all associated parameters for a
-# single step and ensemble member. For further details on what each file type means, see:
+# single step and ctrl/ensemble member. For further details on what each file type means, see:
 # https://meteoswiss.atlassian.net/wiki/spaces/APN/pages/412975206/ICON-22+PP+Naming+scheme+for+intermediate+products#TC-tasks%2C-prepare-step
 #
-# An error during archival will result in all data for that file missing. Thus we can check that all steps and members
+# An error during archival will result in all data for that file missing. Thus we can check that all steps and ctrl/members
 # are present for a single parameter that exists in the file to determine the status.
 PARAMS: list[Parameter] = [
     Parameter(
@@ -95,22 +95,29 @@ def get_param_status(
     Returns a 2d array with dimensions [member, step] containing 1 if the data is present and a 0 if not.
     """
     num_members = COLLECTIONS[model].members
-    # Constant params are only defined on step 0, all others are defined for all steps.
-    if param.is_constant:
-        num_steps = 1
-    else:
-        num_steps = COLLECTIONS[model].steps
-    filter_values = {"param": param.id, "model": model, "date": date, "time": time}
 
-    status = []
-    for member in range(num_members):
-        param_filter = filter_values
-        param_filter["number"] = str(member)
-        param_filter |= param.field_filter
-        steps_present: set[str | int] = list_all_values(*["step"], **param_filter).get(
-            "step", set()
-        )
-        steps_status = [1 if str(s) in steps_present else 0 for s in range(num_steps)]
+    # Constant params are only defined on step 0, all others are defined for all steps.
+    num_steps = 1 if param.is_constant else COLLECTIONS[model].steps
+
+    base_filter = {"param": param.id, "model": model, "date": date, "time": time}
+
+    status: list[list[int]] = []
+
+    # --- Control member (cf) ---
+    cf_filter = {**base_filter, "type": "cf", **param.field_filter}
+    steps_present = list_all_values("step", **cf_filter).get("step", set())
+    status.append([1 if str(s) in steps_present or s in steps_present else 0 for s in range(num_steps)])
+
+    # --- Perturbed members (pf:1..num_members-1) ---
+    for member in range(1, num_members):
+        pf_filter = {
+            **base_filter,
+            "type": "pf",
+            "number": str(member),
+            **param.field_filter,
+        }
+        steps_present = list_all_values("step", **pf_filter).get("step", set())
+        steps_status = [1 if str(s) in steps_present or s in steps_present else 0 for s in range(num_steps)]
         status.append(steps_status)
 
     return status
@@ -192,14 +199,17 @@ def plot_status(ax: Axes, status: list[list[int]], file_suffix: str) -> None:
     ax.set_anchor("W")
     ax.set_aspect("equal")
     ax.set_title(f"Files _FXINP_lfrf<DDHH>0000_<mmm>{file_suffix}", loc="left")
+
     ax.set_xlabel("step")
     ax.set_xticks(
         [x + 0.5 for x in range(num_steps)], labels=[str(s) for s in range(num_steps)]
     )
+
     ax.set_ylabel("member")
+    member_labels = ["ctrl"] + [str(m) for m in range(1, num_members)]
     ax.set_yticks(
         [x + 0.5 for x in range(num_members)],
-        labels=[str(m) for m in range(num_members)],
+        labels=member_labels,
     )
     ax.pcolormesh(
         status, cmap=cmap, shading="flat", edgecolors="k", linewidths=1, vmin=0, vmax=1

--- a/fdb_utils/ci/check_archive_status.py
+++ b/fdb_utils/ci/check_archive_status.py
@@ -112,7 +112,6 @@ def get_param_status(
     for member in range(1, num_members):
         pf_filter = {
             **base_filter,
-            "type": "pf",
             "number": str(member),
             **param.field_filter,
         }

--- a/fdb_utils/ci/check_archive_status.py
+++ b/fdb_utils/ci/check_archive_status.py
@@ -106,7 +106,7 @@ def get_param_status(
     # --- Control member (cf) ---
     cf_filter = {**base_filter, "type": "cf", **param.field_filter}
     steps_present = list_all_values("step", **cf_filter).get("step", set())
-    status.append([1 if str(s) in steps_present or s in steps_present else 0 for s in range(num_steps)])
+    status.append([1 if str(s) in steps_present else 0 for s in range(num_steps)])
 
     # --- Perturbed members (pf:1..num_members-1) ---
     for member in range(1, num_members):
@@ -116,7 +116,7 @@ def get_param_status(
             **param.field_filter,
         }
         steps_present = list_all_values("step", **pf_filter).get("step", set())
-        steps_status = [1 if str(s) in steps_present or s in steps_present else 0 for s in range(num_steps)]
+        steps_status = [1 if str(s) in steps_present else 0 for s in range(num_steps)]
         status.append(steps_status)
 
     return status

--- a/test/test_check_archive_status.py
+++ b/test/test_check_archive_status.py
@@ -127,7 +127,7 @@ def test_plot_status():
     assert ax.get_xlabel() == "step"
     assert [x.get_text() for x in ax.get_xticklabels()] == ["0", "1", "2"]
     assert ax.get_ylabel() == "member"
-    assert [y.get_text() for y in ax.get_yticklabels()] == ["0", "1", "2", "3"]
+    assert [y.get_text() for y in ax.get_yticklabels()] == ["ctrl", "1", "2", "3"]
 
 
 def test_plot_history():
@@ -146,19 +146,25 @@ def test_plot_history():
 
 
 def return_steps(missing_values: dict[tuple[str], dict[str, list[int]]]):
+    """
+    missing_values maps (param,date,time) -> { "ctrl": [...], "1": [...], "2": [...], ... }
+    Control is addressed via type="cf"; perturbed via number="1..".
+    """
     def list_all_values_mock(*filter_keys: str, **filter_by_values: str):
         model = filter_by_values["model"]
         param = filter_by_values["param"]
         num_steps = 1 if param == "500004" else cas.COLLECTIONS[model].steps
 
-        number = filter_by_values["number"]
         date = filter_by_values["date"]
         time = filter_by_values["time"]
-        missing_steps = missing_values.get((param, date, time), {}).get(number, [])
-        steps = []
-        for s in range(num_steps):
-            if s not in missing_steps:
-                steps.append(str(s))
+
+        if filter_by_values.get("type") == "cf":
+            member_key = "ctrl"
+        else:
+            member_key = filter_by_values.get("number")  # "1","2",...
+
+        missing_steps = missing_values.get((param, date, time), {}).get(member_key, [])
+        steps = {str(s) for s in range(num_steps) if s not in missing_steps}
         return {"step": steps}
 
     return list_all_values_mock
@@ -166,9 +172,10 @@ def return_steps(missing_values: dict[tuple[str], dict[str, list[int]]]):
 
 @patch("fdb_utils.ci.check_archive_status.list_all_values")
 def test_get_archive_status(list_values, tmp_path, data_dir):
+    # Row 0 = control ("ctrl"); rows 1.. = numbers "1.."
     missing_values = {
-        ("500004", "20250202", "0300"): {"0": [0], "1": [0]},
-        ("500006", "20250202", "0300"): {"0": [30, 31], "9": [0, 1]},
+        ("500004", "20250202", "0300"): {"ctrl": [0], "1": [0]},
+        ("500006", "20250202", "0300"): {"ctrl": [30, 31], "9": [0, 1]},
         ("500001", "20250202", "0300"): {"1": [0], "2": [10]},
     }
     list_values.side_effect = return_steps(missing_values)
@@ -196,16 +203,18 @@ def test_get_archive_status(list_values, tmp_path, data_dir):
 
 @patch("fdb_utils.ci.check_archive_status.list_all_values")
 def test_historical_archive_status(list_values, tmp_path, data_dir):
+    # helper to fill all members for ch1 (ctrl + 1..10)
+    def all_members_map(step_list):
+        d = {"ctrl": step_list}
+        d.update({str(n): step_list for n in range(1, 11)})
+        return d
+
     # Set one incomplete forecast and one missing forecast.
     missing_values = {
-        ("500004", "20250202", "0000"): {"0": [0]},
-        ("500004", "20250201", "2100"): {str(n): [0] for n in range(11)},
-        ("500006", "20250201", "2100"): {
-            str(n): [s for s in range(33)] for n in range(11)
-        },
-        ("500001", "20250201", "2100"): {
-            str(n): [s for s in range(33)] for n in range(11)
-        },
+        ("500004", "20250202", "0000"): {"ctrl": [0]},  # latest-1 incomplete
+        ("500004", "20250201", "2100"): all_members_map([0]),  # latest-2 missing
+        ("500006", "20250201", "2100"): all_members_map(list(range(33))),
+        ("500001", "20250201", "2100"): all_members_map(list(range(33))),
     }
     list_values.side_effect = return_steps(missing_values)
 


### PR DESCRIPTION
Adapt archival checks and plots to new mars type.

- Use type=cf for control and type=pf with number=1..N-1 for perturbed in get_param_status.

- Plot labels now show ctrl for control instead of 0.