### PR TITLE
remove list of failed files

### DIFF
--- a/fdb_utils/ci/check_archive_status.py
+++ b/fdb_utils/ci/check_archive_status.py
@@ -52,7 +52,7 @@ COLLECTIONS: dict[str, Collection] = {
 }
 
 
-# The poller archives the hourly rotated latlon grib files for constant params (suffix 'c'),
+# The poller archives the hourly grib files for constant params (suffix 'c'),
 # single and multi level params (no suffix), and params on pressure levels (suffix 'p').
 # Each file contains data for all associated parameters for a single step and ctrl/ensemble
 # member. For further details on what each file type means, see:

--- a/fdb_utils/ci/check_archive_status.py
+++ b/fdb_utils/ci/check_archive_status.py
@@ -138,25 +138,6 @@ def get_archive_status(
     return archive_status
 
 
-def fx_filename(suffix: str, member: int, step: int) -> str:
-    """Construct the ICON fxshare filename for the provided parameters."""
-    filename_template = "_FXINP_lfrf{dd:02}{hh:02}000_{mmm:03}"
-    days = step // 24
-    hours = step % 24
-    filename = filename_template.format(dd=days, hh=hours, mmm=member) + suffix
-    return filename
-
-
-def get_failed_files(archive_status: dict[str, list[list[int]]]) -> list[str]:
-    failed_files = []
-    for file_suffix, param_status in archive_status.items():
-        for member, steps_status in enumerate(param_status):
-            for step, success in enumerate(steps_status):
-                if not success:
-                    failed_files.append(fx_filename(file_suffix, member, step))
-    return failed_files
-
-
 class ForecastStatus(IntEnum):
     MISSING = 0
     COMPLETE = 1
@@ -290,14 +271,6 @@ def main(model: str) -> bool:
         f"heatmap_{model}_{last_run_start.strftime('%d%m%y-%H')}.png",
         bbox_inches="tight",
     )
-
-    # If any files in the latest forecast failed, print the names and return failure.
-    if history_status[0] != ForecastStatus.COMPLETE:
-        logging.warning(
-            "The following files failed to archive: %s",
-            get_failed_files(latest_archive_status),
-        )
-        return False
 
     if any(status == ForecastStatus.MISSING for status in history_status):
         logging.warning(

--- a/test/test_check_archive_status.py
+++ b/test/test_check_archive_status.py
@@ -31,26 +31,6 @@ def test_overall_status_incomplete():
     assert cas.summary_status(status_dict) == cas.ForecastStatus.INCOMPLETE
 
 
-def test_fx_filename():
-    assert cas.fx_filename("suf", 0, 0) == "_FXINP_lfrf0000000_000suf"
-    assert cas.fx_filename("", 1, 10) == "_FXINP_lfrf0010000_001"
-    assert cas.fx_filename("s", 123, 49) == "_FXINP_lfrf0201000_123s"
-
-
-def test_get_failed_files():
-    success_dict = {
-        "suf1": [[1, 1, 0], [0, 1, 1]],
-        "suf2": [[0, 1, 1], [1, 1, 1], [1, 0, 1]],
-    }
-    expected_files = [
-        "_FXINP_lfrf0002000_000suf1",
-        "_FXINP_lfrf0000000_001suf1",
-        "_FXINP_lfrf0000000_000suf2",
-        "_FXINP_lfrf0001000_002suf2",
-    ]
-    assert cas.get_failed_files(success_dict) == expected_files
-
-
 def test_last_run_time_ch1():
     icon_1 = cas.COLLECTIONS["icon-ch1-eps"]
 


### PR DESCRIPTION
- the file path template is outdated with the move to icon native grid
- this feature was not used in practice