### PR TITLE
Update Parameter list in check_archive_status.py

### DIFF
--- a/fdb_utils/ci/check_archive_status.py
+++ b/fdb_utils/ci/check_archive_status.py
@@ -63,7 +63,7 @@ COLLECTIONS: dict[str, Collection] = {
 # single parameter that exists in the file to determine the status.
 PARAMS: list[Parameter] = [
     Parameter(
-        id="500004", file_suffix="c", is_constant=True, field_filter={"levtype": "sfc"}
+        id="500007", file_suffix="c", is_constant=True, field_filter={"levtype": "sfc"}
     ),
     Parameter(
         id="500006",

--- a/test/test_check_archive_status.py
+++ b/test/test_check_archive_status.py
@@ -174,7 +174,7 @@ def return_steps(missing_values: dict[tuple[str], dict[str, list[int]]]):
 def test_get_archive_status(list_values, tmp_path, data_dir):
     # Row 0 = control ("ctrl"); rows 1.. = numbers "1.."
     missing_values = {
-        ("500004", "20250202", "0300"): {"ctrl": [0], "1": [0]},
+        ("500007", "20250202", "0300"): {"ctrl": [0], "1": [0]},
         ("500006", "20250202", "0300"): {"ctrl": [30, 31], "9": [0, 1]},
         ("500001", "20250202", "0300"): {"1": [0], "2": [10]},
     }
@@ -211,8 +211,8 @@ def test_historical_archive_status(list_values, tmp_path, data_dir):
 
     # Set one incomplete forecast and one missing forecast.
     missing_values = {
-        ("500004", "20250202", "0000"): {"ctrl": [0]},  # latest-1 incomplete
-        ("500004", "20250201", "2100"): all_members_map([0]),  # latest-2 missing
+        ("500007", "20250202", "0000"): {"ctrl": [0]},  # latest-1 incomplete
+        ("500007", "20250201", "2100"): all_members_map([0]),  # latest-2 missing
         ("500006", "20250201", "2100"): all_members_map(list(range(33))),
         ("500001", "20250201", "2100"): all_members_map(list(range(33))),
     }


### PR DESCRIPTION
This PR updates the constant check from FIS to HSURF.


Since we now validate constants from the native grid files, FIS is no longer appropriate: it is produced by post-processing rather than directly by the ICON model. The previous rotated lat/lon parameter list is shown in the [product template](https://github.com/MeteoSwiss-APN/oprconfig/blob/balfrin/nl/integ_i1e_fcst/templates/prepare_c/rotlatlon/product_consts.nl#L18). HSURF,, by contrast, is a direct model output constant, as defined in the [constants template](https://github.com/MeteoSwiss-APN/oprconfig/blob/balfrin/nl/integ_i2e_fcst/icon_c#L329).